### PR TITLE
1.1.1

### DIFF
--- a/VideoTag.Server/Helpers/Ffprobe.cs
+++ b/VideoTag.Server/Helpers/Ffprobe.cs
@@ -1,7 +1,11 @@
+using System.Text.RegularExpressions;
+
 namespace VideoTag.Server.Helpers;
 
 public static class Ffprobe
 {
+    private static readonly Regex VideoResolutionRegex = new(@"^\d+x\d+");
+    
     public static async Task<int> GetVideoDurationInSecondsAsync(string videoPath)
     {
         var arguments = $"-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"{videoPath}\"";
@@ -12,6 +16,10 @@ public static class Ffprobe
     public static async Task<string> GetVideoResolutionAsync(string videoPath)
     {
         var arguments = $"-v error -select_streams v:0 -show_entries stream=height,width -of csv=s=x:p=0 \"{videoPath}\"";
-        return await ProcessAsyncHelper.RunProcessAndReadStringAsync("ffprobe", arguments);
+        var output = await ProcessAsyncHelper.RunProcessAndReadStringAsync("ffprobe", arguments);
+        var match = VideoResolutionRegex.Match(output);
+        if (!match.Success)
+            throw new Exception("Invalid video resolution");
+        return match.Value;
     }
 }

--- a/VideoTag.Server/appsettings.json
+++ b/VideoTag.Server/appsettings.json
@@ -8,8 +8,5 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=VideoTag.db;Foreign Keys=true"
-  },
-  "Library": {
-    "AllowedFileExtensions": ["mp4", "wmv", "mov", "webm"]
   }
 }

--- a/VideoTag.Server/syncsettings.example.json
+++ b/VideoTag.Server/syncsettings.example.json
@@ -1,6 +1,6 @@
 {
   "Sync": {
-    "AllowedFileExtensions": ["mp4", "wmv", "mov", "webm", "avi", "m4v"],
+    "AllowedFileExtensions": ["mp4", "wmv", "mov", "webm", "avi", "m4v", "mkv", "m2ts"],
     "LibraryPath": "C:\\Path\\To\\Library",
     "DefaultThumbnailSeek": 0.2,
     "ExcludePattern": "__vtignore"


### PR DESCRIPTION
- Ensure video resolution is always returned as `<width>x<height>`. FFProbe for some reason sometimes returns additional values.
- Clean-up settings files.